### PR TITLE
allow page numbers to be shown in output

### DIFF
--- a/lib/klipbook/book_summary.erb
+++ b/lib/klipbook/book_summary.erb
@@ -83,7 +83,11 @@
           <p>
             <%= ERB::Util.html_escape(clipping.text) %>
           </p>
-          <footer><%= clipping.type %><% if clipping.location %> @ loc <%= clipping.location %><% end %></footer>
+          <footer>
+            <%= clipping.type %>
+            <% if include_pages && clipping.page %> on page <%= clipping.page %><% end %>
+            <% if clipping.location %> @ loc <%= clipping.location %><% end %>
+          </footer>
         </li>
         <% end %>
       <% end %>

--- a/lib/klipbook/book_summary.rb
+++ b/lib/klipbook/book_summary.rb
@@ -23,7 +23,8 @@ module Klipbook
       title == other.title && author == other.author
     end
 
-    def as_html
+    def as_html(options={})
+      include_pages = options[:include_pages]
       ERB.new(template, 0, '%<>').result(binding)
     end
 

--- a/lib/klipbook/cli.rb
+++ b/lib/klipbook/cli.rb
@@ -16,6 +16,7 @@ module Klipbook
     end
 
     desc 'summarise CLIPPINGS_FILE  BOOK_NUMBER  OUTPUT_FILE', 'Output an html summary of the clippings for a book'
+    method_option :include_pages, :aliases => '-p', :desc => 'Include page numbers in output when available'
     def summarise(clippings_file=nil, book_number=nil, output_file=nil)
       if (clippings_file.nil? or book_number.nil? or output_file.nil?)
         puts 'Please provide a CLIPPINGS_FILE, BOOK_NUMBER, and OUTPUT_FILE'
@@ -26,7 +27,7 @@ module Klipbook
 
       book_number = book_number.to_i
 
-      Klipbook::Runner.new(clippings_file).print_book_summary(book_number, File.open(output_file, 'w'))
+      Klipbook::Runner.new(clippings_file).print_book_summary(book_number, File.open(output_file, 'w'), options)
     end
 
     map '-v' => :version

--- a/lib/klipbook/clippings_parser.rb
+++ b/lib/klipbook/clippings_parser.rb
@@ -29,6 +29,7 @@ module Klipbook
         author:   extract_author(title_line),
         type:     extract_type(metadata),
         location: extract_location(metadata),
+        page:     extract_page(metadata),
         added_on: extract_added_date(metadata),
         text:     extract_text(text_lines)
       }
@@ -72,6 +73,15 @@ module Klipbook
       return nil if match.empty?
 
       location = match.first[1]
+      location.to_i
+    end
+
+    def extract_page(metadata)
+      match = metadata.scan(/Page (\d+)/)
+
+      return nil if match.empty?
+
+      location = match.first.first
       location.to_i
     end
 

--- a/lib/klipbook/runner.rb
+++ b/lib/klipbook/runner.rb
@@ -16,14 +16,14 @@ module Klipbook
       end
     end
 
-    def print_book_summary(book_number, output)
+    def print_book_summary(book_number, output, options={})
       if book_number < 1 or book_number > @clippings_file.books.length
         $stderr.puts "Sorry but you must specify a book index between 1 and #{@clippings_file.books.length}"
         return
       end
 
       book_summary = @clippings_file.books[book_number - 1]
-      output.write book_summary.as_html
+      output.write book_summary.as_html(options)
     end
   end
 end

--- a/spec/lib/klipbook/clippings_parser_spec.rb
+++ b/spec/lib/klipbook/clippings_parser_spec.rb
@@ -246,6 +246,10 @@ describe Klipbook::ClippingsParser do
         subject[:location].should == 1858
       end
 
+      it 'extracts the page number' do
+        subject[:page].should == 171
+      end
+
       it 'extracts the date' do
         subject[:added_on].should == 'Thursday, April 21, 2011, 07:31 AM'
       end
@@ -262,6 +266,10 @@ describe Klipbook::ClippingsParser do
 
       it 'extracts the first element of the location range' do
         subject[:location].should == 1858
+      end
+
+      it 'extracts the page number' do
+        subject[:page].should == 171
       end
 
       it 'extracts the date' do
@@ -281,6 +289,10 @@ describe Klipbook::ClippingsParser do
         subject[:location].should be_nil
       end
 
+      it 'extracts the page number' do
+        subject[:page].should == 9
+      end
+
       it 'extracts the date' do
         subject[:added_on].should == 'Thursday, April 21, 2011, 07:31 AM'
       end
@@ -296,6 +308,10 @@ describe Klipbook::ClippingsParser do
 
       it 'extracts no location' do
         subject[:location].should be_nil
+      end
+
+      it 'extracts the page number' do
+        subject[:page].should == 9
       end
 
       it 'extracts the date' do


### PR DESCRIPTION
I like to see page numbers when available. If you left this out because you dislike seeing them, perhaps they could be enabled through a command-line option, as in this commit.
